### PR TITLE
Fixed null object bug in ImagesManager

### DIFF
--- a/source/Views/ImagesManager.xaml.cs
+++ b/source/Views/ImagesManager.xaml.cs
@@ -67,7 +67,7 @@ namespace BackgroundChanger.Views
                 ItemImage originalDefault = BackgroundImages.FirstOrDefault(x => x.IsDefault);
 
                 // Delete removed
-                BackgroundImages.Where(x => !x.Name.IsEqual(originalDefault.Name) && x.IsCover == IsCover)?.ForEach(y =>
+                BackgroundImages.Where(x => !x.Name.IsEqual(originalDefault?.Name) && x.IsCover == IsCover)?.ForEach(y =>
                 {
                     if (BackgroundImagesEdited.FirstOrDefault(x => x.FullPath == y.FullPath) == null)
                     {
@@ -80,7 +80,7 @@ namespace BackgroundChanger.Views
                 {
                     ItemImage itemImage = BackgroundImagesEdited[index];
 
-                    if (itemImage.FolderName.IsNullOrEmpty() && !itemImage.Name.IsEqual(originalDefault.Name))
+                    if (itemImage.FolderName.IsNullOrEmpty() && !itemImage.Name.IsEqual(originalDefault?.Name))
                     {
                         Guid ImageGuid = Guid.NewGuid();
                         string OriginalPath = itemImage.Name;


### PR DESCRIPTION
Fixed bug that prevents saving in the Image Manager window when no default background has been selected in the media section of game details.
![Screenshot 2025-05-23 195903](https://github.com/user-attachments/assets/47656012-060c-4b43-8006-bc73b6083657)

This now makes it possible to add media through this plugin without assigning a default image, allowing users for example to only have a video file that plays immediately, instead of needing a default image that eventually transitions into the video.

Simply changed 'originalDefault.Name' to 'originalDefault?.Name' in 2 places. The possibility of originalDefault being null was already accounted for on line:101 but probably forgotten about in the 2 places I made these changes to.

So far I have not noticed any new bugs or undesired behaviour with this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved stability by preventing potential errors when handling images with missing default values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->